### PR TITLE
config: Allow to enable OpenThread optimizations for mbedTLS

### DIFF
--- a/configs/config-tls-generic.h
+++ b/configs/config-tls-generic.h
@@ -388,6 +388,16 @@
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN  CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN
 
+/* Enable OpenThread optimizations. */
+#if defined(CONFIG_MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED)
+#define MBEDTLS_MPI_WINDOW_SIZE            1 /**< Maximum windows size used. */
+#define MBEDTLS_MPI_MAX_SIZE              32 /**< Maximum number of bytes for usable MPIs. */
+#define MBEDTLS_ECP_MAX_BITS             256 /**< Maximum bit size of groups */
+#define MBEDTLS_ECP_WINDOW_SIZE            2 /**< Maximum window size used */
+#define MBEDTLS_ECP_FIXED_POINT_OPTIM      0 /**< Enable fixed-point speed-up */
+#define MBEDTLS_ENTROPY_MAX_SOURCES        1 /**< Maximum number of sources supported */
+#endif
+
 /* User config file */
 
 #if defined(CONFIG_MBEDTLS_USER_CONFIG_ENABLE)


### PR DESCRIPTION
This PR introduces changes needed for OpenThread - mbedTLS integration, needed by https://github.com/zephyrproject-rtos/zephyr/pull/15697. These changes were originally present in that PR.