### PR TITLE
Set speed optimization if ASAN is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,14 @@ if(CONFIG_MBEDTLS_BUILTIN)
   zephyr_library_sources(library/x509write_csr.c)
   zephyr_library_sources(library/xtea.c)
 
+if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT)
+  # i386 assembly code used in MBEDTLS does not compile with size optimization
+  # if address sanitizer is enabled, as such switch default optimization level
+  # to speed
+  set_property(SOURCE library/bignum.c APPEND PROPERTY COMPILE_OPTIONS
+      "${OPTIMIZE_FOR_SPEED_FLAG}")
+endif ()
+
   zephyr_library_link_libraries(mbedTLS)
 else()
   assert(CONFIG_MBEDTLS_LIBRARY "MBEDTLS was enabled, but neither BUILTIN or LIBRARY was selected.")


### PR DESCRIPTION
Set speed optimization, instead of size, in case address sanitizer is
enabled for native_posix. This is need as the i386 assembly code used
in mbetls does not compile if address sanitizer is used together with
size optimization.
