### PR TITLE
cmake: use zephyr_library_app_memory for mem partition placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(CONFIG_MBEDTLS_BUILTIN)
     ${mbedtls_sources}
   )
 
+  zephyr_library_app_memory(k_mbedtls_partition)
 if(CONFIG_ARCH_POSIX AND CONFIG_ASAN AND NOT CONFIG_64BIT)
   # i386 assembly code used in MBEDTLS does not compile with size optimization
   # if address sanitizer is enabled, as such switch default optimization level


### PR DESCRIPTION
This commit follows the change introduced with this PR: https://github.com/zephyrproject-rtos/zephyr/pull/20333

This commit removes the hard coded mbed TLS library name
`lib..__modules__crypto__mbedtls.a` in top-level CMakeLists.txt file and
instead uses zephyr_library_app_memory function.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>