### PR TITLE
DNM zephyr_init: update to support const device objects

### DIFF
--- a/zephyr_init.c
+++ b/zephyr_init.c
@@ -40,7 +40,7 @@ static void init_heap(void)
 #define init_heap(...)
 #endif /* CONFIG_MBEDTLS_ENABLE_HEAP && MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
-static int _mbedtls_init(struct device *device)
+static int _mbedtls_init(const struct device *device)
 {
 	ARG_UNUSED(device);
 


### PR DESCRIPTION
Init function entry points will now take a pointer to a const struct
device. Avoid an incompatible pointer assignment.

DNM until plan for changing to const devices is in place.

Ref zephyrproject-rtos/zephyr#25208

Signed-off-by: Peter A. Bigot <pab@pabigot.com>