### PR TITLE
config-tls-generic: Add config option for MBEDTLS_PKCS1_V21

### DIFF
--- a/configs/config-tls-generic.h
+++ b/configs/config-tls-generic.h
@@ -297,6 +297,10 @@
 #define MBEDTLS_CIPHER_C
 #endif
 
+#if defined(CONFIG_MBEDTLS_PKCS1_V21_ENABLED)
+#define MBEDTLS_PKCS1_V21
+#endif
+
 #if defined(CONFIG_MBEDTLS_MD)
 #define MBEDTLS_MD_C
 #endif


### PR DESCRIPTION
PKCS1 v2.1 defines a more secure scheme by making use of
RSAES-OAEP and RSAASSA-PSS.  Add a config flag to enable
this capability.

Signed-off-by: Eugene Cohen <eugene@nuviainc.com>