### PR TITLE
init: Device instance are all constant now

### DIFF
--- a/zephyr_init.c
+++ b/zephyr_init.c
@@ -40,7 +40,7 @@ static void init_heap(void)
 #define init_heap(...)
 #endif /* CONFIG_MBEDTLS_ENABLE_HEAP && MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
-static int _mbedtls_init(struct device *device)
+static int _mbedtls_init(const struct device *device)
 {
 	ARG_UNUSED(device);
 


### PR DESCRIPTION
Switching device parameter to constant.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>