### PR TITLE
config-tls-generic: Add config option for MBEDTLS_SSL_SERVER_NAME_IND…

### DIFF
--- a/configs/config-tls-generic.h
+++ b/configs/config-tls-generic.h
@@ -410,6 +410,11 @@
 #define MBEDTLS_ENTROPY_MAX_SOURCES        1 /**< Maximum number of sources supported */
 #endif
 
+#if defined(CONFIG_MBEDTLS_SERVER_NAME_INDICATION) && \
+    defined(MBEDTLS_X509_CRT_PARSE_C)
+#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+#endif
+
 /* User config file */
 
 #if defined(CONFIG_MBEDTLS_USER_CONFIG_ENABLE)


### PR DESCRIPTION
…ICATION

This option can be used to enable RFC 6066 server name indication (SNI)
support in SSL. This requires that MBEDTLS_X509_CRT_PARSE_C is also set.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>

This is related to issue https://github.com/zephyrproject-rtos/zephyr/issues/27783