### PR TITLE
config: using CONFIG_MBEDTLS_USER_CONFIG_FILE as safeguard

### DIFF
--- a/configs/config-tls-generic.h
+++ b/configs/config-tls-generic.h
@@ -429,7 +429,7 @@
 
 /* User config file */
 
-#if defined(CONFIG_MBEDTLS_USER_CONFIG_ENABLE)
+#if defined(CONFIG_MBEDTLS_USER_CONFIG_FILE)
 #include CONFIG_MBEDTLS_USER_CONFIG_FILE
 #endif
 


### PR DESCRIPTION
Now using CONFIG_MBEDTLS_USER_CONFIG_FILE instead of
CONFIG_MBEDTLS_USER_CONFIG_ENABLE for inclusion of user config file.

The Kconfig MBEDTLS_USER_CONFIG_ENABLE setting now now determines if
MBEDTLS_USER_CONFIG_FILE is visible.

This removes the problem of MBEDTLS_USER_CONFIG_FILE to be stuck on its
first value.

Users can use MBEDTLS_USER_CONFIG_ENABLE to get the prompt and define
their own value.

As the CONFIG_MBEDTLS_USER_CONFIG_FILE is default promptless then we can
use this setting directly as it will only be defined if another Kconfig
file specifies a default value to use, or user enables:
MBEDTLS_USER_CONFIG_ENABLE.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>