### PR TITLE
mbedtls: remove static keyword from certain function pointers

### DIFF
--- a/mbedtls/library/platform.c
+++ b/mbedtls/library/platform.c
@@ -53,8 +53,8 @@ static void platform_free_uninit( void *ptr )
 #define MBEDTLS_PLATFORM_STD_FREE     platform_free_uninit
 #endif /* !MBEDTLS_PLATFORM_STD_FREE */
 
-static void * (*mbedtls_calloc_func)( size_t, size_t ) = MBEDTLS_PLATFORM_STD_CALLOC;
-static void (*mbedtls_free_func)( void * ) = MBEDTLS_PLATFORM_STD_FREE;
+void * (*mbedtls_calloc_func)( size_t, size_t ) = MBEDTLS_PLATFORM_STD_CALLOC;
+void (*mbedtls_free_func)( void * ) = MBEDTLS_PLATFORM_STD_FREE;
 
 void * mbedtls_calloc( size_t nmemb, size_t size )
 {

--- a/mbedtls/library/platform_util.c
+++ b/mbedtls/library/platform_util.c
@@ -62,7 +62,7 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
-static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
+void * (* const volatile memset_func)( void *, int, size_t ) = memset;
 
 void mbedtls_platform_zeroize( void *buf, size_t len )
 {


### PR DESCRIPTION
TF-M usually downloads mbedtls and then applies a handful of
patches. These patches were forgotten when Zephyr started to use it's
own mbedtls fork with TF-M.

One of these patches has now been re-applied in this commit. It is
needed for an important code sharing optimization documented in a link
below.

The static keyword is removed from three function pointer
declarations. Aside from allowing the optimization described below
this could theoretically backfire.

There could be other non-static symbols that now trigger aliasing
issues.

The compiler could have trouble optimizing now that it doesn't know of
all symbol usages.

But I believe that in practice this will be OK.

I don't know if there are any plans to upstream this patch to mbedtls
itself.

This partially addresses review feedback given in https://github.com/zephyrproject-rtos/zephyr/pull/34263

https://tf-m-user-guide.trustedfirmware.org/docs/technical_references/design_docs/code_sharing.html

Original patch:
https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/commit/lib/ext/mbedcrypto?id=4a5cc9776ed3b053bac57326931f936fbbc660e9

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>