### PR TITLE
Apply Zephyr-specific changes to upstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,32 +304,6 @@ if(ENABLE_TESTING)
     endif()
 endif()
 
-configure_package_config_file(
-    "cmake/MbedTLSConfig.cmake.in"
-    "cmake/MbedTLSConfig.cmake"
-        INSTALL_DESTINATION "cmake")
-
-write_basic_package_version_file(
-    "cmake/MbedTLSConfigVersion.cmake"
-        COMPATIBILITY SameMajorVersion
-        VERSION 3.0.0)
-
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfig.cmake"
-          "${CMAKE_CURRENT_BINARY_DIR}/cmake/MbedTLSConfigVersion.cmake"
-    DESTINATION "cmake")
-
-export(
-    EXPORT MbedTLSTargets
-    NAMESPACE MbedTLS::
-    FILE "cmake/MbedTLSTargets.cmake")
-
-install(
-    EXPORT MbedTLSTargets
-    NAMESPACE MbedTLS::
-    DESTINATION "cmake"
-    FILE "MbedTLSTargets.cmake")
-
 if(CMAKE_VERSION VERSION_GREATER 3.14)
     # Do not export the package by default
     cmake_policy(SET CMP0090 NEW)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Apply Zephyr specific changes to the upstream commits. This changes the directory layout of the repository to match the upstream, and applies a small patch needed to make trusted-firmware-m compile.