### PR TITLE
Disable dependency check for `MBEDTLS_USE_PSA_CRYPTO` on `MBEDTLS_PSA_CRYPTO_C`

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -714,9 +714,9 @@
 #endif
 #undef MBEDTLS_THREADING_IMPL
 
-#if defined(MBEDTLS_USE_PSA_CRYPTO) && !defined(MBEDTLS_PSA_CRYPTO_C)
-#error "MBEDTLS_USE_PSA_CRYPTO defined, but not all prerequisites"
-#endif
+// #if defined(MBEDTLS_USE_PSA_CRYPTO) && !defined(MBEDTLS_PSA_CRYPTO_C)
+// #error "MBEDTLS_USE_PSA_CRYPTO defined, but not all prerequisites"
+// #endif
 
 #if defined(MBEDTLS_VERSION_FEATURES) && !defined(MBEDTLS_VERSION_C)
 #error "MBEDTLS_VERSION_FEATURES defined, but not all prerequisites"


### PR DESCRIPTION
## Description
The config option `MBEDTLS_USE_PSA_CRYPTO` enables PSA/TF-M backend for
MbedTLS. But there is a dependency check for this config option on
`MBEDTLS_PSA_CRYPTO_C` which enables PSA crypto implementation in
MbedTLS.

Using this config option in Zephyr leads to linker error due to multiple
definition of PSA APIs (TF-M and MbedTLS PSA Crypto). For detailed
description check https://github.com/ARMmbed/mbedtls/issues/4597.

Temporarily disable this check till the aforementioned issue is resolved
upstream.

## Status
READY

## Requires Backporting
When there is a bug fix, it should be backported to all maintained and supported branches.
Changes do not have to be backported if:
- This PR is a new feature\enhancement
- This PR contains changes in the API. If this is true, and there is a need for the fix to be backported, the fix should be handled differently in the legacy branch

NO  
Which branch?

## Migrations
If there is any API change, what's the incentive and logic for it.

NO

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
Steps to reproduce are described in https://github.com/ARMmbed/mbedtls/issues/4597
