### PR TITLE
Fix little-endian Microblaze does not work when MBEDTLS_HAVE_ASM is defined

### DIFF
--- a/library/bn_mul.h
+++ b/library/bn_mul.h
@@ -566,10 +566,20 @@
         "andi  r7,   r6, 0xffff \n\t"   \
         "bsrli r6,   r6, 16     \n\t"
 
-#define MULADDC_X1_CORE                 \
+#if(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define MULADDC_LHUI                    \
+        "lhui  r9,   r3,   0    \n\t"   \
+        "addi  r3,   r3,   2    \n\t"   \
+        "lhui  r8,   r3,   0    \n\t"
+#else
+#define MULADDC_LHUI                    \
         "lhui  r8,   r3,   0    \n\t"   \
         "addi  r3,   r3,   2    \n\t"   \
-        "lhui  r9,   r3,   0    \n\t"   \
+        "lhui  r9,   r3,   0    \n\t"
+#endif
+
+#define MULADDC_X1_CORE                    \
+        MULADDC_LHUI                    \
         "addi  r3,   r3,   2    \n\t"   \
         "mul   r10,  r9,  r6    \n\t"   \
         "mul   r11,  r8,  r7    \n\t"   \


### PR DESCRIPTION
## Description
MbedTLS multiplication assembly sources for big numbers not accounting for little endian. Causing zephyr mbedtls unit test to fail when executing mbedtls self-test `MPI test #1 (mul_mpi)`.

Cherry-picked from https://github.com/Mbed-TLS/mbedtls/pull/4686/commits/b88dbdded6bdfdcc0549a193bdd3988267b24da6

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/53899 because this is based on mbedTLS v3.2 which needs TFM v1.7

## Status
**READY**

## Requires Backporting
No, because microblaze support isn't there yet. Therefore this can be considered as part of a new feature.

## Additional comments
Issue was first reported in upstream mbedtls here:
https://github.com/Mbed-TLS/mbedtls/issues/2020
And the fix was implemented in upstream mbedtls here:
https://github.com/Mbed-TLS/mbedtls/pull/4686

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported


## Steps to test or reproduce
compiler/zephyr-sdk: microblaze-gcc from topic-microblaze branch of sdk-ng which based on 0.15
Get the toolchain from here: https://github.com/zephyrproject-rtos/sdk-ng/suites/9030507693/artifacts/417018783

zephyr version: `v3.2.0`
Get the microblaze port here (rebased on `v3.2.0-branch`): https://github.com/alpsayin/zephyr/tree/microblaze_v3.2.0_public
zephyr version: `main`
Get the microblaze port here (rebased on `main`): https://github.com/alpsayin/zephyr/tree/microblaze_public

command: `./scripts/twister -v -p qemu_microblaze -O /scratch/esnap_$USER/twister_out -T tests/crypto/mbedtls`

