### PR TITLE
config_psa: do not update legacy symbols in client-only PSA build

### DIFF
--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -32,7 +32,11 @@
  * before we deduce what built-ins are required. */
 #include "psa/crypto_adjust_config_key_pair_types.h"
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+/* If we are implementing PSA crypto ourselves, then we want to enable the
+ * required built-ins. Otherwise, PSA features will be provided by the server. */
 #include "mbedtls/config_adjust_legacy_from_psa.h"
+#endif
 
 #else /* MBEDTLS_PSA_CRYPTO_CONFIG */
 

--- a/include/mbedtls/config_psa.h
+++ b/include/mbedtls/config_psa.h
@@ -32,7 +32,7 @@
  * before we deduce what built-ins are required. */
 #include "psa/crypto_adjust_config_key_pair_types.h"
 
-#if defined(MBEDTLS_PSA_CRYPTO_C)
+#if defined(MBEDTLS_PSA_CRYPTO_C) || defined(MCUBOOT_USE_PSA_CRYPTO)
 /* If we are implementing PSA crypto ourselves, then we want to enable the
  * required built-ins. Otherwise, PSA features will be provided by the server. */
 #include "mbedtls/config_adjust_legacy_from_psa.h"


### PR DESCRIPTION
## Description

This commits belongs to PR 9138 of the official MbedTLS repo (https://github.com/Mbed-TLS/mbedtls/pull/9138). It will be included both in the next LTS release (3.6.1) as well as the next standard one (4.0) so it can be dropped at the next Zephyr's downstream version bump.