### PR TITLE
Cherry-pick some TLS 1.3 fixes from the `mbedtls-3.6` branch

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4049,7 +4049,7 @@ static int ssl_tls13_session_save(const mbedtls_ssl_session *session,
 }
 
 static int ssl_tls13_session_load(const mbedtls_ssl_session *session,
-                                  unsigned char *buf,
+                                  const unsigned char *buf,
                                   size_t buf_len)
 {
     ((void) session);

--- a/library/ssl_tls13_server.c
+++ b/library/ssl_tls13_server.c
@@ -3109,6 +3109,7 @@ static int ssl_tls13_handshake_wrapup(mbedtls_ssl_context *ssl)
     return 0;
 }
 
+#if defined(MBEDTLS_SSL_SESSION_TICKETS)
 /*
  * Handler for MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET
  */
@@ -3138,7 +3139,6 @@ static int ssl_tls13_write_new_session_ticket_coordinate(mbedtls_ssl_context *ss
     return SSL_NEW_SESSION_TICKET_WRITE;
 }
 
-#if defined(MBEDTLS_SSL_SESSION_TICKETS)
 MBEDTLS_CHECK_RETURN_CRITICAL
 static int ssl_tls13_prepare_new_session_ticket(mbedtls_ssl_context *ssl,
                                                 unsigned char *ticket_nonce,


### PR DESCRIPTION
These fixes will automatically be included in the next 3.6.1 LTS release/update, but for the time being they are required for the TLS 1.3 support PR https://github.com/zephyrproject-rtos/zephyr/pull/77567.

In case Mbed TLS is bumped to 3.6.1 before this PR is merged this PR can be just ignored.