### PR TITLE
Add CNSA presets

### DIFF
--- a/ChangeLog.d/ssl_cnsa_preset.txt
+++ b/ChangeLog.d/ssl_cnsa_preset.txt
@@ -1,0 +1,2 @@
+Features
+   * Add support for CNSA preset that supersedes NSA SuiteB.

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -326,6 +326,7 @@
 
 #define MBEDTLS_SSL_PRESET_DEFAULT              0
 #define MBEDTLS_SSL_PRESET_SUITEB               2
+#define MBEDTLS_SSL_PRESET_CNSA                 3
 
 #define MBEDTLS_SSL_CERT_REQ_CA_LIST_ENABLED       1
 #define MBEDTLS_SSL_CERT_REQ_CA_LIST_DISABLED      0

--- a/include/mbedtls/x509_crt.h
+++ b/include/mbedtls/x509_crt.h
@@ -336,6 +336,11 @@ extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_next;
 extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb;
 
 /**
+ * CNSA profile.
+ */
+extern const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_cnsa;
+
+/**
  * Empty profile that allows nothing. Useful as a basis for constructing
  * custom profiles.
  */

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -5641,6 +5641,16 @@ static const int ssl_preset_suiteb_ciphersuites[] = {
     0
 };
 
+/* As per rfc9151 */
+static const int ssl_preset_cnsa_ciphersuites[] = {
+    MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    MBEDTLS_TLS_RSA_WITH_AES_256_GCM_SHA384,
+    MBEDTLS_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    MBEDTLS_TLS1_3_AES_256_GCM_SHA384,
+    0
+};
+
 #if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 
 /* NOTICE:
@@ -5785,6 +5795,38 @@ static uint16_t ssl_tls12_preset_suiteb_sig_algs[] = {
 };
 #endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
 
+
+/* As per rfc9151 */
+static const uint16_t ssl_preset_cnsa_sig_algs[] = {
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ANY_ALLOWED_ENABLED) && \
+    defined(PSA_WANT_ALG_SHA_384) && \
+    defined(PSA_WANT_ECC_SECP_R1_384)
+    MBEDTLS_TLS1_3_SIG_ECDSA_SECP384R1_SHA384,
+#endif
+#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_384)
+    MBEDTLS_TLS1_3_SIG_RSA_PSS_PSS_SHA384,
+#endif
+#if defined(MBEDTLS_X509_RSASSA_PSS_SUPPORT) && defined(PSA_WANT_ALG_SHA_384)
+    MBEDTLS_TLS1_3_SIG_RSA_PSS_RSAE_SHA384,
+#endif
+    MBEDTLS_TLS_SIG_NONE
+};
+
+
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+static const uint16_t ssl_tls12_preset_cnsa_sig_algs[] = {
+#if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ANY_ALLOWED_ENABLED) && \
+    defined(PSA_WANT_ALG_SHA_384) && \
+    defined(PSA_WANT_ECC_SECP_R1_384)
+    MBEDTLS_SSL_TLS12_SIG_AND_HASH_ALG(MBEDTLS_SSL_SIG_ECDSA, MBEDTLS_SSL_HASH_SHA384),
+#endif
+#if defined(MBEDTLS_RSA_C) && defined(PSA_WANT_ALG_SHA_384)
+    MBEDTLS_SSL_TLS12_SIG_AND_HASH_ALG(MBEDTLS_SSL_SIG_RSA, MBEDTLS_SSL_HASH_SHA384),
+#endif
+    MBEDTLS_TLS_SIG_NONE
+};
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
 #endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 static const uint16_t ssl_preset_suiteb_groups[] = {
@@ -5796,6 +5838,18 @@ static const uint16_t ssl_preset_suiteb_groups[] = {
 #endif
     MBEDTLS_SSL_IANA_TLS_GROUP_NONE
 };
+
+static const uint16_t ssl_preset_cnsa_groups[] = {
+#if defined(MBEDTLS_ECP_DP_SECP384R1_ENABLED)
+    MBEDTLS_SSL_IANA_TLS_GROUP_SECP384R1,
+#endif
+#if defined(PSA_WANT_ALG_FFDH)
+    MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE3072,
+    MBEDTLS_SSL_IANA_TLS_GROUP_FFDHE4096,
+#endif
+    MBEDTLS_SSL_IANA_TLS_GROUP_NONE
+};
+
 
 #if defined(MBEDTLS_DEBUG_C) && defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 /* Function for checking `ssl_preset_*_sig_algs` and `ssl_tls12_preset_*_sig_algs`
@@ -5992,6 +6046,29 @@ int mbedtls_ssl_config_defaults(mbedtls_ssl_config *conf,
      * Preset-specific defaults
      */
     switch (preset) {
+        /*
+         * CNSA
+         */
+        case MBEDTLS_SSL_PRESET_CNSA:
+
+            conf->ciphersuite_list = ssl_preset_cnsa_ciphersuites;
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
+            conf->cert_profile = &mbedtls_x509_crt_profile_cnsa;
+#endif
+#if defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
+#if defined(MBEDTLS_SSL_PROTO_TLS1_2)
+            if (mbedtls_ssl_conf_is_tls12_only(conf)) {
+                conf->sig_algs = ssl_tls12_preset_cnsa_sig_algs;
+            } else
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+            conf->sig_algs = ssl_preset_cnsa_sig_algs;
+#endif /* MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
+#if defined(MBEDTLS_ECP_C) && !defined(MBEDTLS_DEPRECATED_REMOVED)
+            conf->curve_list = NULL;
+#endif
+            conf->group_list = ssl_preset_cnsa_groups;
+            break;
+
         /*
          * NSA Suite B
          */

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -156,6 +156,24 @@ const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_suiteb =
 };
 
 /*
+ * CNSA profile
+ */
+const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_cnsa =
+{
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA384),
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_RSA) |
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_RSASSA_PSS) |
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_ECDSA) |
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_ECKEY),
+#if defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
+    MBEDTLS_X509_ID_FLAG(MBEDTLS_ECP_DP_SECP384R1),
+#else
+    0,
+#endif /* MBEDTLS_PK_HAVE_ECC_KEYS */
+    3072,
+};
+
+/*
  * Empty / all-forbidden profile
  */
 const mbedtls_x509_crt_profile mbedtls_x509_crt_profile_none =


### PR DESCRIPTION
CNSA supersedes NSA SuiteB crypto suites, esp. brings back RSA with higher modulus (>=3072). This was based on RFC9151, see [1].

Implements #4602.

[1] - https://datatracker.ietf.org/doc/rfc9151/

Upstream PR: https://github.com/Mbed-TLS/mbedtls/pull/9460

## Description

Please write a few sentences describing the overall goals of the pull request's commits.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [ ] **changelog** provided, or not required
- [ ] **3.6 backport** done, or not required
- [ ] **2.28 backport** done, or not required
- [ ] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
