### PR TITLE
changes purl to lowercase to be conform to specification

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,4 +4,4 @@ build:
 security:
   external-references:
     - cpe:2.3:a:arm:mbed_tls:3.6.2:*:*:*:*:*:*:*
-    - pkg:github/Mbed-TLS/mbedtls@V3.6.2
+    - pkg:github/mbed-tls/mbedtls@V3.6.2


### PR DESCRIPTION
## Description

Changes the Package URL (PURL) to lowercase as defined in the specification: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#github
See also https://github.com/scanoss/purl2cpe/pull/25

