### PR TITLE
Rename BEFORE_COLON/BC to avoid conflicts

### DIFF
--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -584,11 +584,6 @@ int mbedtls_x509_crl_parse_file(mbedtls_x509_crl *chain, const char *path)
 
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
 /*
- * Return an informational string about the certificate.
- */
-#define BEFORE_COLON    14
-#define BC              "14"
-/*
  * Return an informational string about the CRL.
  */
 int mbedtls_x509_crl_info(char *buf, size_t size, const char *prefix,

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -1746,15 +1746,15 @@ static int x509_info_cert_policies(char **buf, size_t *size,
 /*
  * Return an informational string about the certificate.
  */
-#define BEFORE_COLON    18
-#define BC              "18"
+#define MBEDTLS_BEFORE_COLON        18
+#define MBEDTLS_BEFORE_COLON_STR    "18"
 int mbedtls_x509_crt_info(char *buf, size_t size, const char *prefix,
                           const mbedtls_x509_crt *crt)
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
     char *p;
-    char key_size_str[BEFORE_COLON];
+    char key_size_str[MBEDTLS_BEFORE_COLON];
 
     p = buf;
     n = size;
@@ -1808,13 +1808,13 @@ int mbedtls_x509_crt_info(char *buf, size_t size, const char *prefix,
     MBEDTLS_X509_SAFE_SNPRINTF;
 
     /* Key size */
-    if ((ret = mbedtls_x509_key_size_helper(key_size_str, BEFORE_COLON,
+    if ((ret = mbedtls_x509_key_size_helper(key_size_str, MBEDTLS_BEFORE_COLON,
                                             mbedtls_pk_get_name(&crt->pk))) != 0) {
         return ret;
     }
 
-    ret = mbedtls_snprintf(p, n, "\n%s%-" BC "s: %d bits", prefix, key_size_str,
-                           (int) mbedtls_pk_get_bitlen(&crt->pk));
+    ret = mbedtls_snprintf(p, n, "\n%s%-" MBEDTLS_BEFORE_COLON_STR "s: %d bits",
+                           prefix, key_size_str, (int) mbedtls_pk_get_bitlen(&crt->pk));
     MBEDTLS_X509_SAFE_SNPRINTF;
 
     /*

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -520,8 +520,8 @@ int mbedtls_x509_csr_parse_file(mbedtls_x509_csr *csr, const char *path)
 #endif /* MBEDTLS_FS_IO */
 
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
-#define BEFORE_COLON    14
-#define BC              "14"
+#define MBEDTLS_BEFORE_COLON       14
+#define MBEDTLS_BEFORE_COLON_STR   "14"
 /*
  * Return an informational string about the CSR.
  */
@@ -531,7 +531,7 @@ int mbedtls_x509_csr_info(char *buf, size_t size, const char *prefix,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t n;
     char *p;
-    char key_size_str[BEFORE_COLON];
+    char key_size_str[MBEDTLS_BEFORE_COLON];
 
     p = buf;
     n = size;
@@ -552,13 +552,13 @@ int mbedtls_x509_csr_info(char *buf, size_t size, const char *prefix,
                                     csr->sig_opts);
     MBEDTLS_X509_SAFE_SNPRINTF;
 
-    if ((ret = mbedtls_x509_key_size_helper(key_size_str, BEFORE_COLON,
+    if ((ret = mbedtls_x509_key_size_helper(key_size_str, MBEDTLS_BEFORE_COLON,
                                             mbedtls_pk_get_name(&csr->pk))) != 0) {
         return ret;
     }
 
-    ret = mbedtls_snprintf(p, n, "\n%s%-" BC "s: %d bits\n", prefix, key_size_str,
-                           (int) mbedtls_pk_get_bitlen(&csr->pk));
+    ret = mbedtls_snprintf(p, n, "\n%s%-" MBEDTLS_BEFORE_COLON_STR "s: %d bits\n",
+                           prefix, key_size_str, (int) mbedtls_pk_get_bitlen(&csr->pk));
     MBEDTLS_X509_SAFE_SNPRINTF;
 
     /*


### PR DESCRIPTION
## Description

Rename the `BEFORE_COLON` and `BC` defines to include a `MBEDTLS_` prefix and expand the `BC` to `BEFORE_COLON`.
The existing names are rather short and are not properly namespaced, increasing the likelihood for conflicts.

The defines are not even used in `x509_crl.c`, so remove them entirely there.

One example is the Renesas RA HAL headers that have variables named `BC`. Those headers are included into the mbedtls module via the `sys/socket.h` and `arpa/inet.h` headers in `library/x509.crt.c` which will eventually include CPU-specific headers containing the Renesas HAL. The conflict can be triggered with the https sample: `west build -p auto -b ek_ra6m4 zephyr/samples/net/sockets/http_server`, which will lead to
~~~
/home/stefan/Downloads/zephyr_test/modules/crypto/mbedtls/library/x509_crt.c:1750:25: error: expected identifier or '(' before string constant
 1750 | #define BC              "18"
      |                         ^~~~
/home/stefan/Downloads/zephyr_test/modules/hal/renesas/drivers/ra/fsp/src/bsp/cmsis/Device/RENESAS/Include/R7FA6M4AF.h:8100:27: note: in expansion of macro 'BC'
 8100 |             __IOM uint8_t BC   : 3;    /*!< [2..0] Bit Counter                                                        */
      |                           ^~
~~~
The include chain can be investigated by copying the GCC command, removing the `-M*` options, and adding `-H`.

Arguably, this conflict can also be solved by not including the `socket.h` and `inet.h` headers, e.g., by adding a special `#ifdef __ZEPHYR__` case that defaults to the software version of `inet_pton()` just as it is done for Win32.
It could also be solved in the Renesas HAL header, but it makes more sense to me to fix the `#define`.

Consider this an RFC. Let me know if you have any better ideas to fix this. If this is accepted here I will submit it upstream as well.

## PR checklist

- [x] **changelog** not required
- [x] **3.6 backport** not required
- [x] **2.28 backport** not required
- [x] **tests** not required
