### PR TITLE
fix: library: ssl_tls12_client debug message

### DIFF
--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2764,7 +2764,7 @@ static int ssl_write_client_key_exchange(mbedtls_ssl_context *ssl)
 
         header_len = 4;
 
-        MBEDTLS_SSL_DEBUG_MSG(1, ("Perform PSA-based ECDH computation."));
+        MBEDTLS_SSL_DEBUG_MSG(3, ("Perform PSA-based ECDH computation."));
 
         /*
          * Generate EC private key for ECDHE exchange.


### PR DESCRIPTION

## Description

Fixed a debug message log level. It was printing at error level which may confuse people who do debug

## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [x] **3.6 backport** done, or not required
- [x] **2.28 backport** done, or not required
- [x] **tests** provided, or not required

