### PR TITLE
modules: mbedtls: Fix IAR __packed problem

### DIFF
--- a/library/alignment.h
+++ b/library/alignment.h
@@ -48,10 +48,26 @@
  * This results in a single load / store instruction (if unaligned access is supported).
  * According to that document, this is only supported on certain architectures.
  */
-    #define UINT_UNALIGNED
+#define UINT_UNALIGNED
+
+/* Some products, like Zephyr, defines __packed as a macro for attribute(packed) and
+ * that does not work with typedefs, so if __packed is defined, undef it for the
+ * typedefs and restore it afterwards.
+ */
+#ifdef __packed
+#pragma push_macro("__packed")
+#undef __packed
+#define MBEDTLS_IAR_PACKED_MACRO_USED
+#endif
+
 typedef uint16_t __packed mbedtls_uint16_unaligned_t;
 typedef uint32_t __packed mbedtls_uint32_unaligned_t;
 typedef uint64_t __packed mbedtls_uint64_unaligned_t;
+
+#ifdef MBEDTLS_IAR_PACKED_MACRO_USED
+#undef MBEDTLS_IAR_PACKED_MACRO_USED
+#pragma pop_macro("__packed")
+#endif
 #elif defined(MBEDTLS_COMPILER_IS_GCC) && (MBEDTLS_GCC_VERSION >= 40504) && \
     ((MBEDTLS_GCC_VERSION < 60300) || (!defined(MBEDTLS_EFFICIENT_UNALIGNED_ACCESS)))
 /*


### PR DESCRIPTION
## Description

Since __packed is a reserved keyword for the IAR compilers, and Zephyr defines it attribute(__packed__), some typdef constructs in mbedtls does not work with attribute(packed), only with the keyword packed.

This fix checks if __packed is a macro and temporary undefines it so the typedefs works correctly.



## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

-  **changelog** not required
-  **3.6 backport** not sure  if required
-  **2.28 backport** not required
-  **tests** not required


