### PR TITLE
cmake: Bump minimum cmake to 3.20.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 # We specify a minimum requirement of 3.10.2, but for now use 3.5.1 here
 # until our infrastructure catches up.
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 include(CMakePackageConfigHelpers)
 

--- a/programs/test/cmake_package/CMakeLists.txt
+++ b/programs/test/cmake_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 #
 # Simulate configuring and building Mbed TLS as the user might do it. We'll

--- a/programs/test/cmake_package_install/CMakeLists.txt
+++ b/programs/test/cmake_package_install/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 #
 # Simulate configuring and building Mbed TLS as the user might do it. We'll

--- a/programs/test/cmake_subproject/CMakeLists.txt
+++ b/programs/test/cmake_subproject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 # Test the target renaming support by adding a prefix to the targets built
 set(MBEDTLS_TARGET_PREFIX subproject_test_)


### PR DESCRIPTION
Zephyr uses cmake 3.20.0 as the minimum version for a long time. Set the same requirement here to avoid possible issues in future.

