### PR TITLE
Remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "framework"]
-	path = framework
-	url = https://github.com/Mbed-TLS/mbedtls-framework


### PR DESCRIPTION
This submodule is not correctly initialized as a submodule, which when trying to use mbedtls in a yocto environment with gitsm, fails to fetch, as it is trying to fetch a stale submodule.