### PR TITLE
[zep fromtree] cmake: make Threads package search quiet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 # We now potentially need to link all executables against PThreads, if available
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
+find_package(Threads QUIET)
 
 # If this is the root project add longer list of available CMAKE_BUILD_TYPE values
 if(NOT MBEDTLS_AS_SUBPROJECT)


### PR DESCRIPTION
This prevents printing message

"-- Could NOT find Threads (missing: Threads_FOUND)"

on platforms like Zephyr where threading is not provided by standard libraries.


(cherry picked from commit 92cfa4e70e937ca39fdc9c237895f12af548e12b)