### PR TITLE
[zep noup] module.yml: update CPE vendor from arm to trustedfirmware

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,5 +4,5 @@ build:
   kconfig-ext: True
 security:
   external-references:
-    - cpe:2.3:a:arm:mbed_tls:4.1.0:*:*:*:*:*:*:*
+    - cpe:2.3:a:trustedfirmware:mbed_tls:4.1.0:*:*:*:*:*:*:*
     - pkg:github/Mbed-TLS/mbedtls@v4.1.0


### PR DESCRIPTION
The Mbed TLS project has been under Trusted Firmware governance since 2020, and as of NIST's 6/05/2026 deprecation remap, all `cpe:2.3:a:arm:mbed_tls:*` entries are deprecated and redirect to
`cpe:2.3:a:trustedfirmware:mbed_tls:*`. So `trustedfirmware` is the correct vendor for current NVD matching.

Related discussion https://github.com/Mbed-TLS/mbedtls/issues/9982