### PR TITLE
[zep noup] Rename module and remove requirements for Zephyr CMake/Kconfig

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,7 +1,7 @@
-name: mbedtls
+name: mbedtls-3.6
 build:
-  cmake-ext: True
-  kconfig-ext: True
+  cmake-ext: False
+  kconfig-ext: False
 security:
   external-references:
     - cpe:2.3:a:trustedfirmware:mbed_tls:3.6.7:*:*:*:*:*:*:*


### PR DESCRIPTION
Cherry-pick of https://github.com/zephyrproject-rtos/mbedtls/commit/a00e23de17b6b0a0de28e180cb186da6f0008836 that was forgotten in https://github.com/zephyrproject-rtos/mbedtls/pull/99.
Specifically for the update in Zephyr's `v4.4-branch`: https://github.com/zephyrproject-rtos/zephyr/pull/113689